### PR TITLE
ci: Update test command to output results directly

### DIFF
--- a/.github/workflows/build_library.yaml
+++ b/.github/workflows/build_library.yaml
@@ -35,16 +35,5 @@ jobs:
 
     - name: Run tests
       run: 
-        dotnet test --logger trx; trx 
+        dotnet test --logger trx; trx --output
       working-directory: lib
-
- #   - name: Upload test results
- #     uses: actions/upload-artifact@v4
- #     with:
- #       name: test-results
- #       path: lib/tests/library_test_results.trx
-
-#    - name: Output test results to GitHub Summary
-#      run: 
-#        cat tests/library_test_results.trx >> $GITHUB_STEP_SUMMARY
-#      working-directory: lib

--- a/.github/workflows/build_library.yaml
+++ b/.github/workflows/build_library.yaml
@@ -1,7 +1,4 @@
 name: CI - Library
-permissions:
-  contents: read
-  pull-requests: write
 
 on:
   push:
@@ -12,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/build_library.yaml
+++ b/.github/workflows/build_library.yaml
@@ -1,4 +1,7 @@
 name: CI - Library
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:

--- a/lib/tests/DartsScorer.Tests/GameTests.cs
+++ b/lib/tests/DartsScorer.Tests/GameTests.cs
@@ -7,7 +7,7 @@ public class GameTests
     public GameType GameTypes { get; private set; }
 
     [Test]
-    public void Instansitation_Success()
+    public void Game_Instansitation_Success()
     {
         var gameVariant = new X01Variant();
 
@@ -17,7 +17,7 @@ public class GameTests
     }
 
     [Test]
-    public void Instansitation_Failure()
+    public void Game_Instansitation_Failure()
     {
         var gameVariant = new X01Variant();        
         var gameVariantToFail = new KillerVarient();

--- a/lib/tests/DartsScorer.Tests/PlayerTests.cs
+++ b/lib/tests/DartsScorer.Tests/PlayerTests.cs
@@ -1,14 +1,14 @@
 public class PlayerTests
 {
     [Test]
-    public void Instansitation()
+    public void Player_Instansitation()
     {
         var player = new Player("John");
         Assert.That(player.Name, Is.EqualTo("John"));
     }
 
     [Test]
-    public void Instansitation_Fail()
+    public void Player_Instansitation_Fail()
     {
         var player = new Player("John");
         Assert.That(player.Name, !Is.EqualTo("Steven"));

--- a/lib/tests/DartsScorer.Tests/TeamTests.cs
+++ b/lib/tests/DartsScorer.Tests/TeamTests.cs
@@ -1,23 +1,23 @@
 namespace DartsScorer.Tests;
 
-public class TestTests
+public class TeamTests
 {
     [Test]
-    public void Instansitation()
+    public void Team_Instansitation()
     {
         var team = new Team("Fancy New Team");
         Assert.That(team.Name, Is.EqualTo("Fancy New Team"));
     }
 
     [Test]
-    public void Instansitation_Fail()
+    public void Team_Instansitation_Fail()
     {
         var team = new Team("Fancy New Team");
         Assert.That(team.Players.Count, Is.EqualTo(0));
     }
 
     [Test]
-    public void AddSinglePlayer_Sucess()
+    public void Team_AddSinglePlayer_Sucess()
     {
         var team = new Team("Fancy New Team");
         var player = new Player("John");
@@ -28,7 +28,7 @@ public class TestTests
     }
 
     [Test]
-    public void AddSinglePlayer_PlayerCount_Fail()
+    public void Team_AddSinglePlayer_PlayerCount_Fail()
     {
         var team = new Team("Fancy New Team");
         var player = new Player("John");
@@ -38,7 +38,7 @@ public class TestTests
     }
 
     [Test]
-    public void AddMultiplePlayer_Sucess()
+    public void Team_AddMultiplePlayer_Sucess()
     {
         var team = new Team("Fancy New Team");
         var player1 = new Player("John");
@@ -52,7 +52,7 @@ public class TestTests
     }
 
     [Test]
-    public void AddMultiplePlayer_CannotAddDuplicates()
+    public void Team_AddMultiplePlayer_CannotAddDuplicates()
     {
         var team = new Team("Fancy New Team");
         var player1 = new Player("John");

--- a/lib/tests/DartsScorer.Tests/VariantPlayerTests.cs
+++ b/lib/tests/DartsScorer.Tests/VariantPlayerTests.cs
@@ -4,7 +4,7 @@ public class VariantPlayerTests
 {
 
     [Test]
-    public void Instansitation()
+    public void VariantPlayer_Instansitation()
     {
         var player = new Player("Fancy New Team");
         var variantPlayer = new VariantPlayer(player);


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build_library.yaml` file. The change modifies the command used to run tests by adding an output option to the `dotnet test` command.

* [`.github/workflows/build_library.yaml`](diffhunk://#diff-f667efc367819e18a3f6c158be69809f2cbaf3f3ce7ab1468dd0d1729039e996L38-L50): Updated the `dotnet test` command to include the `--output` option.