### PR TITLE
fix: enhance CI workflow for code coverage and test results publishing

### DIFF
--- a/.github/workflows/build_library.yaml
+++ b/.github/workflows/build_library.yaml
@@ -42,56 +42,71 @@ jobs:
         dotnet test --configuration Release --verbosity normal --logger trx --collect:"XPlat Code Coverage"
       working-directory: lib
 
-    # Upload test results as an artifact
-    - name: Combine Coverage Reports # This is because one report is produced per project, and we want one result for all of them.
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.4.4
-      with:
-        reports: "**/*.cobertura.xml" # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
-        targetdir: "${{ github.workspace }}" # REQUIRED # The directory where the generated report should be saved.
-        reporttypes: "Cobertura" # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, Html_Dark, Html_Light, Html_BlueRed, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlInline_AzurePipelines_Light, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MarkdownSummaryGithub, MarkdownDeltaSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, TextDeltaSummary, Xml, XmlSummary
-        verbosity: "Info" # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
-        title: "Code Coverage" # Optional title.
-        tag: "${{ github.run_number }}_${{ github.run_id }}" # Optional tag or build version.
-        customSettings: "" # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
-        toolpath: "reportgeneratortool" # Default directory for installing the dotnet tool.
+  publish-code-coverage:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    steps:
+      # Upload test results as an artifact
+      - name: Combine Coverage Reports # This is because one report is produced per project, and we want one result for all of them.
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.4.4
+        with:
+          reports: "**/*.cobertura.xml" # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
+          targetdir: "${{ github.workspace }}" # REQUIRED # The directory where the generated report should be saved.
+          reporttypes: "Cobertura" # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, Html_Dark, Html_Light, Html_BlueRed, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlInline_AzurePipelines_Light, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MarkdownSummary, MarkdownSummaryGithub, MarkdownDeltaSummary, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, TextDeltaSummary, Xml, XmlSummary
+          verbosity: "Info" # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
+          title: "Code Coverage" # Optional title.
+          tag: "${{ github.run_number }}_${{ github.run_id }}" # Optional tag or build version.
+          customSettings: "" # Optional custom settings (separated by semicolon). See: https://github.com/danielpalme/ReportGenerator/wiki/Settings.
+          toolpath: "reportgeneratortool" # Default directory for installing the dotnet tool.
 
-    - name: Upload Combined Coverage XML
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage
-        path: ${{ github.workspace }}/Cobertura.xml
-        retention-days: 5
-  
-    - name: Publish Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: "Cobertura.xml"
-        badge: true
-        fail_below_min: false # just informative for now
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: false
-        indicators: true
-        output: both
-        thresholds: "10 30"
+      - name: Upload Combined Coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ${{ github.workspace }}/Cobertura.xml
+          retention-days: 5
+    
+      - name: Publish Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: "Cobertura.xml"
+          badge: true
+          fail_below_min: false # just informative for now
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: false
+          indicators: true
+          output: both
+          thresholds: "10 30"
 
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2.9.1
-      if: github.event_name == 'pull_request'
-      with:
-          recreate: true
-          path: code-coverage-results.md
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2.9.1
+        if: github.event_name == 'pull_request'
+        with:
+            recreate: true
+            path: code-coverage-results.md
 
+  publish-test-results:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    steps:
+      - name: Upload Test Result Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: ${{ github.workspace }}/**/TestResults/**/*
+          retention-days: 5
 
-    - name: Upload Test Result Files
-      uses: actions/upload-artifact@v4
-      with:
-         name: test-results
-         path: ${{ github.workspace }}/**/TestResults/**/*
-         retention-days: 5
-
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2.18.0
-      if: always()
-      with:
-         trx_files: "${{ github.workspace }}/**/TestResults/**/*.trx"
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2.18.0
+        if: always()
+        with:
+          trx_files: "${{ github.workspace }}/**/TestResults/**/*.trx"


### PR DESCRIPTION
This pull request introduces new jobs to the GitHub Actions workflow to enhance the handling of code coverage and test results. These changes aim to improve the automation and reporting processes for the project.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/build_library.yaml`](diffhunk://#diff-f667efc367819e18a3f6c158be69809f2cbaf3f3ce7ab1468dd0d1729039e996R45-R52): Added a `publish-code-coverage` job to publish code coverage results. This job depends on the `build` job and includes permissions for reading contents, writing pull requests, and writing checks.
* [`.github/workflows/build_library.yaml`](diffhunk://#diff-f667efc367819e18a3f6c158be69809f2cbaf3f3ce7ab1468dd0d1729039e996L85-R100): Added a `publish-test-results` job to upload test result files. This job also depends on the `build` job and includes permissions for reading contents, writing pull requests, and writing checks.