### PR TITLE
feat: add creation date to Leg and order legs by creation date in Rou…

### DIFF
--- a/DartsScorer.Main/Match/Leg.cs
+++ b/DartsScorer.Main/Match/Leg.cs
@@ -7,7 +7,11 @@ public class Leg : CommonLeg
     public Leg()
     {
         NextThrow = 1;
+        CreationDate = DateTime.Now;
     }
+
+    public DateTime CreationDate { get; set; }
+
     public override void ThrowFirst(ThrowScore throwScore)
     {
         if (NextThrow != 1)
@@ -43,13 +47,5 @@ public class Leg : CommonLeg
         Throws.Add(throwScore);
         NextThrow = 1;
         IsComplete = true;
-    }
-
-    public void Clear()
-    {
-        CurrentScore = 0;
-        Throws.Clear();
-        NextThrow = 1;
-        IsComplete = false;
     }
 }

--- a/DartsScorer.Main/Match/RoundTheBoard/Match.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/Match.cs
@@ -6,18 +6,16 @@ public sealed class Match : CommonMatch
     {
         DartsMatchType = DartsMatchType.RoundTheBoard;
     }
-
+    
+    public override bool IsMatchComplete => Players.Count(f => (f as RoundTheBoardPlayer).Finished()) == 1;
+    public RoundTheBoardPlayer Winner => Players.FirstOrDefault(f => (f as RoundTheBoardPlayer).Finished()) as RoundTheBoardPlayer;
     public override string Name => "Round The Board";
 
     public override void StartMatch()
     {
         if (CanStartMatch())
         {
-            SetCurrentPlayer((Player.Player)Players.First());
+            SetCurrentPlayer(Players.First());
         }
     }
-
-    public override bool IsMatchComplete => Players.Count(f => (f as RoundTheBoardPlayer).Finished()) == 1;
-    
-    public RoundTheBoardPlayer Winner => Players.FirstOrDefault(f => (f as RoundTheBoardPlayer).Finished()) as RoundTheBoardPlayer;
 }

--- a/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
@@ -9,24 +9,6 @@ public class RoundTheBoardPlayer(string name) : MatchPlayer(new Player.Player(na
 
     private const int WinningNumber = 20;
     private bool HasWon { get; set; }
-    /*
-    public void StartThrow()
-    {
-        if (Legs.Any())
-        {
-            if (Legs.Last().IsComplete == false)
-            {
-                throw new InvalidOperationException("The last leg has not finished.");
-            }
-        }
-        else if (Legs.Count != 0 && CurrentLeg == null)
-        {
-            throw new InvalidOperationException("The last leg has not finished.");
-        }
-        
-        CurrentLeg = new Leg();
-    }
-*/
     public override void Throw(BoardScore boardScore, Multiplier multiplier)
     {
         // if the leg is finished return
@@ -78,7 +60,10 @@ public class RoundTheBoardPlayer(string name) : MatchPlayer(new Player.Player(na
     // add method to end the throw and add the leg to the list of legs
     public override void EndThrow()
     {
-        if (CurrentLeg != null) Legs.Add(CurrentLeg);
+        if (CurrentLeg != null)
+        {
+            Legs.Add(CurrentLeg);
+        }
         CurrentLeg = null;
         // CurrentLeg = null; // this is the bit that is causing the set current player leg null
     }

--- a/DartsScorer.Main/Player/MatchPlayer.cs
+++ b/DartsScorer.Main/Player/MatchPlayer.cs
@@ -5,14 +5,17 @@ using DartsScorer.Main.Scoring;
 namespace DartsScorer.Main.Player;
 
 public abstract class MatchPlayer(Player player) : Player(player.Name)
-{
+{  
     public ICollection<Leg?> Legs { get; set; } = new List<Leg?>();
-    
-   // public abstract void StartThrow();
+
+    public IOrderedEnumerable<Leg?> OrderedDescendingLegs()
+    {
+        return Legs.OrderByDescending(leg => leg.CreationDate.Ticks);
+    }
+
     public abstract void Throw(BoardScore one, Multiplier multiplier);
     public abstract void EndThrow();
     public abstract bool Finished();
-    protected internal bool HasFinishedLeg { get; set; } = false;
 
     public Leg? CurrentLeg;
     public void Throw(string dartThrow)

--- a/DartsScorer.Web/Views/RoundTheBoard/Index.cshtml
+++ b/DartsScorer.Web/Views/RoundTheBoard/Index.cshtml
@@ -84,9 +84,16 @@
                     </form>
                 }
                 
-                for(var leg = 0; leg < currentPlayer.Legs.Count; leg++)
+                // sort the currentPlayer.Legs by the createion date, but to the exact millisecond
+                // then iterate over each leg and display the leg number and the throws in that leg
+                
+                var legArray = currentPlayer.OrderedDescendingLegs().ToArray();
+                var currentLegLocation = 0;
+                foreach (var leg in legArray)
                 {
-                    <p><b>Leg @(leg + 1)</b> - @string.Join(", ", currentPlayer.Legs.ElementAt(leg).Throws.Select(thr => thr.ToString()))</p>
+                    var throws = leg.Throws;
+                    <p><b>Leg @(legArray.Length - currentLegLocation)</b>: @string.Join(", ", throws.Select(thr => thr.ToString()))</p>
+                    currentLegLocation++;
                 }
             }
         }

--- a/tests/DartsScore.RoundTheBoard/LegTests.cs
+++ b/tests/DartsScore.RoundTheBoard/LegTests.cs
@@ -88,4 +88,22 @@ public class LegTests
         Assert.That(roundTheBoardPlayer.RequiredBoardNumber, Is.EqualTo( 3));
         Assert.That(roundTheBoardPlayer.Legs.Count, Is.EqualTo(1));
     }
+
+    [Test]
+    public void RoundTheBoard_Leg_Order_Test()
+    {
+        var roundTheBoardPlayer = new RoundTheBoardPlayer("Fancy New Player Name");
+        
+        roundTheBoardPlayer.Throw(BoardScore.One, Multiplier.Single);
+        roundTheBoardPlayer.Throw(BoardScore.Two, Multiplier.Single);
+        roundTheBoardPlayer.Throw(BoardScore.Seven, Multiplier.Single);
+        
+        roundTheBoardPlayer.Throw(BoardScore.Two, Multiplier.Single);
+        roundTheBoardPlayer.Throw(BoardScore.One, Multiplier.Single);
+        roundTheBoardPlayer.Throw(BoardScore.Six, Multiplier.Single);
+        
+        Assert
+            .That(roundTheBoardPlayer.Legs.Last().CreationDate, 
+                Is.GreaterThan(roundTheBoardPlayer.Legs.First().CreationDate));
+    }
 }


### PR DESCRIPTION
This pull request includes several changes to the `DartsScorer` project, focusing on adding new properties, removing unused methods, and improving the sorting and display of legs in the game. The most important changes include adding a `CreationDate` property to the `Leg` class, removing the `Clear` method from `Leg`, and sorting legs by creation date.

### Enhancements to `Leg` and `MatchPlayer` classes:

* [`DartsScorer.Main/Match/Leg.cs`](diffhunk://#diff-3f6bbddc6b572e741413ff46476bf390af2050321861465d27e44c5ee2c9b826R10-R14): Added a `CreationDate` property to the `Leg` class to track when each leg was created.
* [`DartsScorer.Main/Player/MatchPlayer.cs`](diffhunk://#diff-6b51ac26c7173f0daf4c75c564d1ee5c2caf6dd8a5f65ba49078bbae3cf64bbcL11-L15): Added an `OrderedDescendingLegs` method to the `MatchPlayer` class to sort legs by their creation date in descending order.

### Removal of unused methods:

* [`DartsScorer.Main/Match/Leg.cs`](diffhunk://#diff-3f6bbddc6b572e741413ff46476bf390af2050321861465d27e44c5ee2c9b826L47-L54): Removed the unused `Clear` method from the `Leg` class.
* [`DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs`](diffhunk://#diff-e8a84665acb0e62d637e27f1c2b6c288399de14f6bdb9473c05a98752d125974L12-L29): Removed the commented-out `StartThrow` method from the `RoundTheBoardPlayer` class.

### Improvements to leg sorting and display:

* [`DartsScorer.Web/Views/RoundTheBoard/Index.cshtml`](diffhunk://#diff-10906f51147b2ccd500ccd54d94cc608ee13a77d29c4fddf107aa809d1be4504L87-R96): Updated the view to sort `currentPlayer.Legs` by creation date and display the legs in the correct order.

### Test updates:

* [`tests/DartsScore.RoundTheBoard/LegTests.cs`](diffhunk://#diff-daabdbc3215d43897a0ff2c3491426e62f8b9e6e03d69044f0880f4c0f3355b9R91-R108): Added a new test `RoundTheBoard_Leg_Order_Test` to verify that legs are ordered correctly by their creation date.…ndTheBoardPlayer