### PR TITLE
refactor: remove outdated comments and enhance current leg display in…

### DIFF
--- a/DartsScorer.Web/Views/RoundTheBoard/Index.cshtml
+++ b/DartsScorer.Web/Views/RoundTheBoard/Index.cshtml
@@ -84,9 +84,6 @@
                     </form>
                 }
                 
-                // sort the currentPlayer.Legs by the createion date, but to the exact millisecond
-                // then iterate over each leg and display the leg number and the throws in that leg
-                
                 var legArray = currentPlayer.OrderedDescendingLegs().ToArray();
                 var currentLegLocation = 0;
                 foreach (var leg in legArray)

--- a/DartsScorer.Web/Views/RoundTheBoard/PlayerScore.cshtml
+++ b/DartsScorer.Web/Views/RoundTheBoard/PlayerScore.cshtml
@@ -1,3 +1,4 @@
+@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata
 @model DartsScorer.Main.Match.RoundTheBoard.RoundTheBoardPlayer
 
 @{
@@ -9,7 +10,13 @@
         <h3>Throw: @Model.CurrentLeg?.NextThrow</h3>
         <p>Score Needed: 
         @{
-             <player>@Model.RequiredBoardNumber</player>
-         }</p>
+            <player>@Model.RequiredBoardNumber</player>
+        }</p>
+        @if (Model.CurrentLeg != null)
+        {
+            <p>Current Leg:
+            @string.Join(", ", Model.CurrentLeg.Throws.Select(thr => thr.ToString()))
+            </p>
+        }
     } 
 }


### PR DESCRIPTION
This pull request includes changes to the `DartsScorer.Web/Views/RoundTheBoard` views to improve the display and functionality of player scores and current legs.

Improvements to player score display:

* [`DartsScorer.Web/Views/RoundTheBoard/PlayerScore.cshtml`](diffhunk://#diff-8056507f2d26a1f8ae8e5ae4093a808b19c81db2f39d25fbe4769e7db14d8a60R15-R20): Added a check to display the current leg and its throws if the `Model.CurrentLeg` is not null.

Code cleanup:

* [`DartsScorer.Web/Views/RoundTheBoard/Index.cshtml`](diffhunk://#diff-10906f51147b2ccd500ccd54d94cc608ee13a77d29c4fddf107aa809d1be4504L87-L89): Removed outdated comments related to sorting `currentPlayer.Legs` by creation date.

Dependency inclusion:

* [`DartsScorer.Web/Views/RoundTheBoard/PlayerScore.cshtml`](diffhunk://#diff-8056507f2d26a1f8ae8e5ae4093a808b19c81db2f39d25fbe4769e7db14d8a60R1): Added `@using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata` directive.… PlayerScore view