### PR TITLE
feat: add MatchInProgress property to match classes and update views …

### DIFF
--- a/DartsScorer.Main/Match/CommonMatch.cs
+++ b/DartsScorer.Main/Match/CommonMatch.cs
@@ -16,6 +16,8 @@ public abstract class CommonMatch
     private readonly List<Set> _sets = [];
 
     public IReadOnlyList<Set> Sets => _sets.AsReadOnly();
+    
+    public abstract bool MatchInProgress { get; set; }
 
     public void AddPlayer(Player.MatchPlayer player)
     {

--- a/DartsScorer.Main/Match/Killer/Match.cs
+++ b/DartsScorer.Main/Match/Killer/Match.cs
@@ -9,6 +9,8 @@ public class Match: CommonMatch
     }
 
     public override string Name { get; } = "Killer";
+    public override bool MatchInProgress { get; set; }
+
     public override void StartMatch()
     {
         if (CanStartMatch())

--- a/DartsScorer.Main/Match/RoundTheBoard/Match.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/Match.cs
@@ -11,11 +11,14 @@ public sealed class Match : CommonMatch
     public RoundTheBoardPlayer Winner => Players.FirstOrDefault(f => (f as RoundTheBoardPlayer).Finished()) as RoundTheBoardPlayer;
     public override string Name => "Round The Board";
 
+    public override bool MatchInProgress { get; set; }
+
     public override void StartMatch()
     {
         if (CanStartMatch())
         {
             SetCurrentPlayer(Players.First());
+            MatchInProgress = true;
         }
     }
 }

--- a/DartsScorer.Main/Match/x01/Match.cs
+++ b/DartsScorer.Main/Match/x01/Match.cs
@@ -20,11 +20,13 @@ public class Match : CommonMatch
     }
 
     public override string Name { get; } = "x01";
+    public override bool MatchInProgress { get; set; }
+
     public override void StartMatch()
     {
         if (CanStartMatch())
         {
-            
+            MatchInProgress = true;
         }
     }
 

--- a/DartsScorer.Web/Views/RoundTheBoard/Index.cshtml
+++ b/DartsScorer.Web/Views/RoundTheBoard/Index.cshtml
@@ -17,9 +17,9 @@
             }
         }
         
-        @Html.Partial("MatchPlayers", Model.Players)
+        @Html.Partial("MatchPlayers", Model)
         @{
-            if (Model.Players.Any())
+            if (Model.Players.Any() && !Model.MatchInProgress)
             {
                 <form asp-action="StartMatch" method="post">
                     <button type="submit" class="btn btn-primary">Start Match</button>

--- a/DartsScorer.Web/Views/RoundTheBoard/MatchPlayers.cshtml
+++ b/DartsScorer.Web/Views/RoundTheBoard/MatchPlayers.cshtml
@@ -1,9 +1,26 @@
-@model IEnumerable<DartsScorer.Main.Player.MatchPlayer>
+@using DartsScorer.Main.Match.RoundTheBoard
+@model DartsScorer.Main.Match.RoundTheBoard.Match
 
 <h2>Match Players</h2>
-<dl>
-    @foreach (var player in Model)
+@if (Model.MatchInProgress)
+{
+    <dl>
+    @foreach (var modelPlayer in Model.Players)
     {
-        <dt>@player.Name</dt>
+        <dt>@{
+               var player = modelPlayer as RoundTheBoardPlayer;
+               @modelPlayer.Name <span>(@player.RequiredBoardNumber)</span>
+           }</dt>
     }
-</dl>
+    </dl>
+}
+else
+{
+    <dl>
+        @foreach (var player in Model.Players)
+        {
+            <dt>@player.Name</dt>
+        }
+    </dl>
+    
+}

--- a/DartsScorer.Web/Views/RoundTheBoard/PlayerScore.cshtml
+++ b/DartsScorer.Web/Views/RoundTheBoard/PlayerScore.cshtml
@@ -7,7 +7,7 @@
         var player = Model;
         <h2>Current Player: @Model.Name</h2>
         <h3>Leg: @(Model.Legs.Count+1)</h3>
-        <h3>Throw: @Model.CurrentLeg?.NextThrow</h3>
+        <h3>Throw: @(Model.CurrentLeg == null ? 1 : @Model.CurrentLeg?.NextThrow)</h3>
         <p>Score Needed: 
         @{
             <player>@Model.RequiredBoardNumber</player>


### PR DESCRIPTION
This pull request introduces several significant changes to the `DartsScorer` project, primarily focusing on adding a new property to track the match progress and updating the views to reflect this new property. The most important changes include the addition of the `MatchInProgress` property to various match classes, updates to the `RoundTheBoard` views, and conditional rendering based on the new property.

### Core Functionality Updates:
* Added the `MatchInProgress` property to the `CommonMatch` class and its derived classes (`Killer`, `RoundTheBoard`, and `x01`) to track whether a match is currently in progress. [[1]](diffhunk://#diff-e9eba8665b7dc7ae772100ca53207397ffdfc78a43da6a92d87341a8319711f5R20-R21) [[2]](diffhunk://#diff-bda3ca6f6a40caea682170830f59eb57ec44b6612cb2432ba9e3ca4bd58e6d50R12-R13) [[3]](diffhunk://#diff-f6df0e2f720e07bb64e35162fde153d7139a1147ffbce2272e5ca2d2b8488ec2R14-R21) [[4]](diffhunk://#diff-36134ec406f708818ab69562436d00de0868cfe8a859b1437725f15e9b370305R23-R29)

### View Updates:
* Updated `RoundTheBoard/Index.cshtml` to use the `MatchInProgress` property for conditional rendering of the "Start Match" button.
* Modified `RoundTheBoard/MatchPlayers.cshtml` to use the `Match` model instead of `IEnumerable<MatchPlayer>` and added conditional rendering based on the `MatchInProgress` property.
* Adjusted `RoundTheBoard/PlayerScore.cshtml` to handle cases where `CurrentLeg` is null, ensuring the correct throw number is displayed.…accordingly