### PR TITLE
feat: update winning condition logic in RoundTheBoardPlayer class

### DIFF
--- a/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
@@ -45,15 +45,15 @@ public class RoundTheBoardPlayer(string name) : MatchPlayer(new Player.Player(na
     
     private void UpdateRequiredBoardNumber(ThrowScore newThrow)
     {
+        if (newThrow.Score == WinningNumber)
+        {
+            HasWon = true;
+        }
+        
         if (newThrow.NumberScore == RequiredBoardNumber && !HasWon && WinningNumber != RequiredBoardNumber)
         {
             var nextNumber = newThrow.Score + 1;
             RequiredBoardNumber = nextNumber > 20 ? RequiredBoardNumber : nextNumber;
-        }
-
-        if (newThrow.NumberScore == 20 && RequiredBoardNumber == 20)
-        {
-            HasWon = true;
         }
     }
     


### PR DESCRIPTION
This pull request includes changes to the `UpdateRequiredBoardNumber` method in the `RoundTheBoardPlayer` class to fix a bug related to updating the required board number and determining if a player has won. The most important changes are:

Bug Fixes:

* [`DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs`](diffhunk://#diff-e8a84665acb0e62d637e27f1c2b6c288399de14f6bdb9473c05a98752d125974L48-R56): Corrected the condition to set `HasWon` to true when the throw score matches the winning number.
* [`DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs`](diffhunk://#diff-e8a84665acb0e62d637e27f1c2b6c288399de14f6bdb9473c05a98752d125974L48-R56): Adjusted the logic to update the `RequiredBoardNumber` correctly when the throw score matches the required board number and the player has not yet won.