### PR TITLE
feat: simplify winning condition check in RoundTheBoardPlayer class

### DIFF
--- a/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
@@ -51,6 +51,10 @@ public class RoundTheBoardPlayer(string name) : MatchPlayer(new Player.Player(na
             RequiredBoardNumber = nextNumber > 20 ? RequiredBoardNumber : nextNumber;
             HasWon = newThrow.Score == WinningNumber;
         }
+        else if (newThrow.NumberScore == WinningNumber && RequiredBoardNumber == 20)
+        {
+            HasWon = true;
+        }
     }
     
     // add method to end the throw and add the leg to the list of legs

--- a/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
@@ -45,15 +45,11 @@ public class RoundTheBoardPlayer(string name) : MatchPlayer(new Player.Player(na
     
     private void UpdateRequiredBoardNumber(ThrowScore newThrow)
     {
-        if (newThrow.Score == WinningNumber)
-        {
-            HasWon = true;
-        }
-        
         if (newThrow.NumberScore == RequiredBoardNumber && !HasWon && WinningNumber != RequiredBoardNumber)
         {
             var nextNumber = newThrow.Score + 1;
             RequiredBoardNumber = nextNumber > 20 ? RequiredBoardNumber : nextNumber;
+            HasWon = newThrow.Score == WinningNumber;
         }
     }
     


### PR DESCRIPTION
This pull request includes a small but important change to the `UpdateRequiredBoardNumber` method in the `RoundTheBoardPlayer` class. The change ensures that the `HasWon` property is updated correctly when a player scores the winning number.

* [`DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs`](diffhunk://#diff-e8a84665acb0e62d637e27f1c2b6c288399de14f6bdb9473c05a98752d125974L48-R52): Moved the logic that sets `HasWon` to `true` when the player scores the winning number inside the condition that checks if the new throw matches the required board number. This ensures that `HasWon` is only set when the player has actually won.