### PR TITLE
chore: update project files to set IsPackable to false and modify .gi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,5 @@ FodyWeavers.xsd
 # add visual sutio out and bin
 out/
 bin/
+
+nupkgs/

--- a/DartsScorer.Console/DartsScorer.Console.csproj
+++ b/DartsScorer.Console/DartsScorer.Console.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DartsScorer.Web/DartsScorer.Web.csproj
+++ b/DartsScorer.Web/DartsScorer.Web.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/tests/DartsScorer.Checkout/DartsScorer.Checkout.csproj
+++ b/tests/DartsScorer.Checkout/DartsScorer.Checkout.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/tests/DartsScorer.Killer/DartsScorer.Killer.csproj
+++ b/tests/DartsScorer.Killer/DartsScorer.Killer.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>

--- a/tests/DartsScorer.Tests/DartsScorer.Tests.csproj
+++ b/tests/DartsScorer.Tests/DartsScorer.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/DartsScorer.x01/DartsScorer.x01.csproj
+++ b/tests/DartsScorer.x01/DartsScorer.x01.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>


### PR DESCRIPTION
This pull request includes changes to the project files to ensure that the `IsPackable` property is set correctly across different projects. The changes primarily focus on adding or removing the `IsPackable` property to ensure consistency.

Changes to project files:

* [`DartsScorer.Console/DartsScorer.Console.csproj`](diffhunk://#diff-67215c7f233c7077c5ccc526806bd22c5c89517d15bac0b034a5898796bdacc4R8): Added the `IsPackable` property and set it to `false`.
* [`DartsScorer.Web/DartsScorer.Web.csproj`](diffhunk://#diff-b72a077edc9c289d82f1a220c559a437e02ee3a9100c82934e3fceea70554d12R7): Added the `IsPackable` property and set it to `false`.
* [`tests/DartsScorer.Checkout/DartsScorer.Checkout.csproj`](diffhunk://#diff-8a7197c5712812222a5e4c74fb592b77b43bb766d8d4cdad121efc10810a4910L7): Ensured the `IsPackable` property is set to `false` by removing an extra line.
* [`tests/DartsScorer.Killer/DartsScorer.Killer.csproj`](diffhunk://#diff-364923a8025f29cf5432a90e141914e6d3eaffef7e92a0fefeaa232011e064fdL7): Ensured the `IsPackable` property is set to `false` by removing an extra line.
* [`tests/DartsScorer.Tests/DartsScorer.Tests.csproj`](diffhunk://#diff-790cf4670496ebe3ce14c187cb06e991d37618c7a46bf1621a8753a381c823d1L7): Ensured the `IsPackable` property is set to `false` by removing an extra line.
* [`tests/DartsScorer.x01/DartsScorer.x01.csproj`](diffhunk://#diff-17bb767a94b090d3aa77c9dd1d3bad6f4d82691d9c6a84b2bd2708d3933b286cL7): Ensured the `IsPackable` property is set to `false` by removing an extra line.…tignore