### PR TITLE
feat: add GitHub Actions workflow for publishing Docker package

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,0 +1,30 @@
+name: Publish Docker Package
+
+# run on a workflow dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish'
+        required: true
+        default: 'latest'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Log in to GitHub Docker registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u matpadley --password-stdin
+
+      - name: Build Docker image
+        run: docker build -t ghcr.io/matpadley/darts:${{ github.event.release.tag_name }} .
+
+      - name: Push Docker image
+        run: docker push ghcr.io/matpadley/darts:${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Expose the port
-# Expose the port
 EXPOSE 5000
 
 # Set the environment variable to specify the port


### PR DESCRIPTION
This pull request includes changes to automate the publishing of Docker packages and a minor adjustment in the `Dockerfile`. The most important changes are listed below:

Automation of Docker package publishing:

* [`.github/workflows/publish_container.yml`](diffhunk://#diff-f8c2c5d22345c127f9ea5b9fd919a8f40733f3b275e0e307f717852977f43c26R1-R30): Added a new GitHub Actions workflow to publish Docker packages. This workflow is triggered manually and includes steps for checking out the repository, logging in to the GitHub Docker registry, building the Docker image, and pushing the Docker image to the registry.

Minor adjustment:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L32): Removed a redundant comment before the `EXPOSE 5000` line.