### PR TITLE
Refactor RoundTheBoardPlayer logic for winning condition and add unit…

### DIFF
--- a/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
+++ b/DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs
@@ -11,15 +11,15 @@ public class RoundTheBoardPlayer(string name) : MatchPlayer(new Player.Player(na
     
     public override void UpdateRequiredBoardNumber(ThrowScore newThrow)
     {
-        if (newThrow.NumberScore == RequiredBoardNumber && !HasWon && WinningNumber != RequiredBoardNumber)
+        if (newThrow.Score == WinningNumber && RequiredBoardNumber == 20)
+        {
+            HasWon = true;
+        }
+        else if (newThrow.NumberScore == RequiredBoardNumber && !HasWon && WinningNumber != RequiredBoardNumber)
         {
             var nextNumber = newThrow.Score + 1;
             RequiredBoardNumber = nextNumber > 20 ? RequiredBoardNumber : nextNumber;
             HasWon = newThrow.Score == WinningNumber;
-        }
-        else if (newThrow.NumberScore == WinningNumber && RequiredBoardNumber == 20)
-        {
-            HasWon = true;
         }
     }
 

--- a/tests/DartsScore.RoundTheBoard/MatchRunTests.cs
+++ b/tests/DartsScore.RoundTheBoard/MatchRunTests.cs
@@ -188,6 +188,67 @@ public class MatchRunTests
         Assert.That(_match.Players.First(f => (f as RoundTheBoardPlayer)?.Name == "new player").Finished(), Is.True);
         Assert.That(_match.Winner.Name, Is.EqualTo("new player"));
     }
+    
+    [Test]
+    public void RoundTheBoard_Single_Player_No_Finish_With_Double_Or_treble_Twenty()
+    {
+        var player1 = new RoundTheBoardPlayer("new player");
+
+        _match.AddPlayer(player1);
+
+        _match.StartMatch();
+
+        var player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        
+        TryParse(player?.RequiredBoardNumber.ToString(), out BoardScore boardScore1);
+        TryParse((player?.RequiredBoardNumber + 3).ToString(), out BoardScore boardScore2);
+        TryParse((player?.RequiredBoardNumber + 3).ToString(), out BoardScore boardScore3);
+        
+        //first throw
+        player?.Throw(boardScore1, Multiplier.Treble);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.Throw(boardScore2, Multiplier.Treble);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.Throw(boardScore3, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.EndThrow();
+        
+        _match.UpdatePlayer(player!);
+        
+        //second throw
+        player?.Throw(BoardScore.Thirteen, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.Throw(BoardScore.Fourteen, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.Throw(BoardScore.Fifteen, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.EndThrow();
+        
+        _match.UpdatePlayer(player!);
+        
+        // third throw
+        player?.Throw(BoardScore.Sixteen, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.Throw(BoardScore.Seventeen, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.Throw(BoardScore.Eighteen, Multiplier.Single);
+        player = _match.CurrentPlayer as RoundTheBoardPlayer;
+        player?.EndThrow();
+        
+        _match.UpdatePlayer(player!);
+        
+        player?.Throw(BoardScore.Nineteen, Multiplier.Single);
+        player?.Throw(BoardScore.Twenty, Multiplier.Double);
+        player?.Throw(BoardScore.Eighteen, Multiplier.Single);
+        player?.EndThrow();
+        
+        _match.UpdatePlayer(player!);
+        
+        Assert.That(_match.Players.First(f => (f as RoundTheBoardPlayer)?.Name == "new player").Finished(), Is.False);
+        
+        // assert that _match.Winner is null
+        Assert.That(_match.Winner, Is.Null);
+    }
 
     [Test]
     public void RoundTheBoard_MultiPlayer_Player_First_Leg()


### PR DESCRIPTION
This pull request includes changes to the `RoundTheBoardPlayer` class and its corresponding tests to address the logic for determining when a player has won the game. The most important changes involve updating the win condition logic and adding a new test case to ensure the correctness of this logic.

### Logic updates:

* [`DartsScorer.Main/Match/RoundTheBoard/RoundTheBoardPlayer.cs`](diffhunk://#diff-e8a84665acb0e62d637e27f1c2b6c288399de14f6bdb9473c05a98752d125974L14-L23): Modified the `UpdateRequiredBoardNumber` method to correctly handle the win condition when the `RequiredBoardNumber` is 20 and the `newThrow.Score` matches the `WinningNumber`.

### Testing updates:

* [`tests/DartsScore.RoundTheBoard/MatchRunTests.cs`](diffhunk://#diff-ab19032b5388517bd2df45d966a4a0914044f090be8dd65fa22603c5ce217e0eR192-R252): Added a new test method `RoundTheBoard_Single_Player_No_Finish_With_Double_Or_treble_Twenty` to verify that a player does not finish the game incorrectly when throwing a double or treble twenty.… test for no finish scenario